### PR TITLE
BP-7 | Don’t kick active clients

### DIFF
--- a/local_node.c
+++ b/local_node.c
@@ -181,9 +181,6 @@ usteer_update_client_active_bytes(struct sta_info *si, struct blob_attr *data)
 	struct blob_attr *tb_bytes[__MSG_MAX_BYTES];
 	struct blob_attr *tb_rxtx[__MSG_MAX_RXTX];
 
-	if (!si->connected)
-		return;
-
 	blobmsg_parse(policy_bytes, __MSG_MAX_BYTES, tb_bytes, blobmsg_data(data), blobmsg_data_len(data));
 	if (!tb_bytes[MSG_BYTES])
 		return;

--- a/local_node.c
+++ b/local_node.c
@@ -161,6 +161,50 @@ usteer_local_node_assoc_update(struct sta_info *si, struct blob_attr *data)
 }
 
 static void
+usteer_update_client_active_bytes(struct sta_info *si, struct blob_attr *data)
+{
+	enum {
+		MSG_RX,
+		MSG_TX,
+		MSG_BYTES,
+		__MSG_MAX_BYTES,
+		__MSG_MAX_RXTX,
+	};
+	static struct blobmsg_policy policy_bytes[__MSG_MAX_BYTES] = {
+			[MSG_BYTES] = { "bytes", BLOBMSG_TYPE_TABLE },
+	};
+	static struct blobmsg_policy policy_rxtx[__MSG_MAX_RXTX] = {
+			[MSG_RX] = { "rx", BLOBMSG_TYPE_INT64 },
+			[MSG_TX] = { "tx", BLOBMSG_TYPE_INT64 },
+	};
+	struct sta_active_bytes *active_bytes;
+	struct blob_attr *tb_bytes[__MSG_MAX_BYTES];
+	struct blob_attr *tb_rxtx[__MSG_MAX_RXTX];
+
+	if (!si->connected)
+		return;
+
+	blobmsg_parse(policy_bytes, __MSG_MAX_BYTES, tb_bytes, blobmsg_data(data), blobmsg_data_len(data));
+	if (!tb_bytes[MSG_BYTES])
+		return;
+
+	blobmsg_parse(policy_rxtx, __MSG_MAX_RXTX, tb_rxtx, blobmsg_data(tb_bytes[MSG_BYTES]), blobmsg_data_len(tb_bytes[MSG_BYTES]));
+	if (!tb_rxtx[MSG_RX] || !tb_rxtx[MSG_TX])
+		return;
+
+	uint16_t index = si->active_bytes.index + 1;
+	active_bytes = &si->active_bytes.data[index];
+	active_bytes->rx = blobmsg_get_u64(tb_rxtx[MSG_RX]);
+	active_bytes->tx = blobmsg_get_u64(tb_rxtx[MSG_TX]);
+
+	uint16_t config_active_seconds = 30;
+	if (index >= (config_active_seconds + 3)) {
+		index -= config_active_seconds + 3;
+	}
+	si->active_bytes.index = index;
+}
+
+static void
 usteer_local_node_set_assoc(struct usteer_local_node *ln, struct blob_attr *cl)
 {
 	struct usteer_node *node = &ln->node;
@@ -194,6 +238,8 @@ usteer_local_node_set_assoc(struct usteer_local_node *ln, struct blob_attr *cl)
 		usteer_local_node_assoc_update(si, cur);
 		if (si->connected == 1)
 			n_assoc++;
+
+		usteer_update_client_active_bytes(si, cur);
 	}
 
 	node->n_assoc = n_assoc;

--- a/local_node.c
+++ b/local_node.c
@@ -194,8 +194,8 @@ usteer_update_client_active_bytes(struct sta_info *si, struct blob_attr *data)
 	active_bytes->rx = blobmsg_get_u64(tb_rxtx[MSG_RX]);
 	active_bytes->tx = blobmsg_get_u64(tb_rxtx[MSG_TX]);
 
-	if (index >= (config.kick_client_active_sec + 3)) {
-		index -= config.kick_client_active_sec + 3;
+	if (index >= si->active_bytes.size) {
+		index -= si->active_bytes.size;
 	}
 	si->active_bytes.index = index;
 }

--- a/local_node.c
+++ b/local_node.c
@@ -189,14 +189,13 @@ usteer_update_client_active_bytes(struct sta_info *si, struct blob_attr *data)
 	if (!tb_rxtx[MSG_RX] || !tb_rxtx[MSG_TX])
 		return;
 
-	uint16_t index = si->active_bytes.index + 1;
+	uint32_t index = si->active_bytes.index + 1;
 	active_bytes = &si->active_bytes.data[index];
 	active_bytes->rx = blobmsg_get_u64(tb_rxtx[MSG_RX]);
 	active_bytes->tx = blobmsg_get_u64(tb_rxtx[MSG_TX]);
 
-	uint16_t config_active_seconds = 30;
-	if (index >= (config_active_seconds + 3)) {
-		index -= config_active_seconds + 3;
+	if (index >= (config.kick_client_active_sec + 3)) {
+		index -= config.kick_client_active_sec + 3;
 	}
 	si->active_bytes.index = index;
 }

--- a/main.c
+++ b/main.c
@@ -93,7 +93,7 @@ void usteer_init_defaults(void)
 	config.load_kick_reason_code = 5; /* WLAN_REASON_DISASSOC_AP_BUSY */
 
 	config.kick_client_active_sec = 30;
-	config.kick_client_active_kbits = 50;
+	config.kick_client_active_bits = 50000;
 
 	config.debug_level = MSG_FATAL;
 }

--- a/main.c
+++ b/main.c
@@ -92,6 +92,9 @@ void usteer_init_defaults(void)
 	config.load_kick_min_clients = 10;
 	config.load_kick_reason_code = 5; /* WLAN_REASON_DISASSOC_AP_BUSY */
 
+	config.kick_client_active_sec = 30;
+	config.kick_client_active_kbits = 50;
+
 	config.debug_level = MSG_FATAL;
 }
 

--- a/openwrt/usteer/files/etc/init.d/usteer
+++ b/openwrt/usteer/files/etc/init.d/usteer
@@ -67,7 +67,8 @@ uci_usteer() {
 		roam_scan_snr roam_scan_interval \
 		roam_trigger_snr roam_trigger_interval \
 		load_kick_threshold load_kick_delay load_kick_min_clients \
-		load_kick_reason_code
+		load_kick_reason_code \
+		kick_client_active_sec kick_client_active_kbits
 	do
 		uci_option_to_json "$cfg" "$opt"
 	done

--- a/openwrt/usteer/files/etc/init.d/usteer
+++ b/openwrt/usteer/files/etc/init.d/usteer
@@ -68,7 +68,7 @@ uci_usteer() {
 		roam_trigger_snr roam_trigger_interval \
 		load_kick_threshold load_kick_delay load_kick_min_clients \
 		load_kick_reason_code \
-		kick_client_active_sec kick_client_active_kbits
+		kick_client_active_sec kick_client_active_bits
 	do
 		uci_option_to_json "$cfg" "$opt"
 	done

--- a/policy.c
+++ b/policy.c
@@ -186,7 +186,7 @@ usteer_check_request(struct sta_info *si, enum usteer_event_type type)
 	return false;
 }
 
-static uint64_t
+uint64_t
 usteer_local_node_active_bytes(struct sta_info *si)
 {
 	struct sta_active_bytes_queue bytes_queue = si->active_bytes;

--- a/policy.c
+++ b/policy.c
@@ -196,9 +196,14 @@ usteer_local_node_active_bytes(struct sta_info *si)
 	uint64_t rx_delta;
 	uint64_t tx_delta;
 
-	uint32_t old = index + 3;
-	if (old >= (config.kick_client_active_sec + 3)) {
-		old -= (config.kick_client_active_sec + 3);
+	uint32_t size_config = config.kick_client_active_sec;
+	uint32_t size_alloc = si->active_bytes.size;
+	bool time_shorter = size_config < size_alloc;
+
+	uint32_t index_dist = time_shorter ? size_alloc - size_config : 0;
+	uint32_t old = index + 3 + index_dist;
+	if (old >= si->active_bytes.size) {
+		old -= si->active_bytes.size;
 	}
 
 	data_old = bytes_queue.data[old];
@@ -206,8 +211,8 @@ usteer_local_node_active_bytes(struct sta_info *si)
 	rx_delta = data_new.rx - data_old.rx;
 	tx_delta = data_new.tx - data_old.tx;
 
-	uint64_t diff_sec = config.kick_client_active_sec;
-	return (rx_delta + tx_delta) / diff_sec;
+	uint64_t time_diff = time_shorter ? size_config : size_alloc;
+	return (rx_delta + tx_delta) / time_diff;
 }
 
 static bool

--- a/policy.c
+++ b/policy.c
@@ -190,16 +190,15 @@ static uint64_t
 usteer_local_node_active_bytes(struct sta_info *si)
 {
 	struct sta_active_bytes_queue bytes_queue = si->active_bytes;
-	uint16_t index = bytes_queue.index;
+	uint32_t index = bytes_queue.index;
 	struct sta_active_bytes data_old;
 	struct sta_active_bytes data_new;
 	uint64_t rx_delta;
 	uint64_t tx_delta;
 
-	uint16_t old = index + 3;
-	uint16_t config_kick_active_seconds = 30;
-	if (old >= (config_kick_active_seconds + 3)) {
-		old -= (config_kick_active_seconds + 3);
+	uint32_t old = index + 3;
+	if (old >= (config.kick_client_active_sec + 3)) {
+		old -= (config.kick_client_active_sec + 3);
 	}
 
 	data_old = bytes_queue.data[old];
@@ -207,14 +206,15 @@ usteer_local_node_active_bytes(struct sta_info *si)
 	rx_delta = data_new.rx - data_old.rx;
 	tx_delta = data_new.tx - data_old.tx;
 
-	return (rx_delta + tx_delta) / config_kick_active_seconds;
+	uint64_t diff_sec = config.kick_client_active_sec;
+	return (rx_delta + tx_delta) / diff_sec;
 }
 
 static bool
 is_active_client(struct sta_info *si)
 {
 	uint64_t client_active_ratio = usteer_local_node_active_bytes(si) * 8;
-	uint64_t config_kick_active_ratio = 50 * 1000;
+	uint64_t config_kick_active_ratio = config.kick_client_active_kbits * 1000;
 	if (client_active_ratio >= config_kick_active_ratio) {
 		MSG_T("load_kick_active",
 			  "client "MAC_ADDR_FMT" is still active (config=%llu) (real=%llu)",

--- a/policy.c
+++ b/policy.c
@@ -213,9 +213,9 @@ usteer_local_node_active_bytes(struct sta_info *si)
 static bool
 is_active_client(struct sta_info *si)
 {
-	uint64_t client_active_ratio;
+	uint64_t client_active_ratio = usteer_local_node_active_bytes(si) * 8;
 	uint64_t config_kick_active_ratio = 50 * 1000;
-	if ((client_active_ratio = usteer_local_node_active_bytes(si)) >= config_kick_active_ratio) {
+	if (client_active_ratio >= config_kick_active_ratio) {
 		MSG_T("load_kick_active",
 			  "client "MAC_ADDR_FMT" is still active (config=%llu) (real=%llu)",
 			  MAC_ADDR_DATA(si->sta->addr), config_kick_active_ratio, client_active_ratio);

--- a/policy.c
+++ b/policy.c
@@ -187,7 +187,7 @@ usteer_check_request(struct sta_info *si, enum usteer_event_type type)
 }
 
 uint64_t
-usteer_local_node_active_bytes(struct sta_info *si)
+usteer_local_node_active_bits(struct sta_info *si)
 {
 	struct sta_active_bytes_queue bytes_queue = si->active_bytes;
 	uint32_t index = bytes_queue.index;
@@ -212,23 +212,22 @@ usteer_local_node_active_bytes(struct sta_info *si)
 	tx_delta = data_new.tx - data_old.tx;
 
 	uint64_t time_diff = time_shorter ? size_config : size_alloc;
-	return (rx_delta + tx_delta) / time_diff;
+	return ((rx_delta + tx_delta) / time_diff) * 8;
 }
 
 static bool
 is_active_client(struct sta_info *si)
 {
-	uint64_t client_active_ratio = usteer_local_node_active_bytes(si) * 8;
-	uint64_t config_kick_active_ratio = config.kick_client_active_kbits * 1000;
-	if (client_active_ratio >= config_kick_active_ratio) {
+	uint64_t client_active_ratio = usteer_local_node_active_bits(si);
+	if (client_active_ratio >= config.kick_client_active_bits) {
 		MSG_T("load_kick_active",
 			  "client "MAC_ADDR_FMT" is still active (config=%llu) (real=%llu)",
-			  MAC_ADDR_DATA(si->sta->addr), config_kick_active_ratio, client_active_ratio);
+			  MAC_ADDR_DATA(si->sta->addr), config.kick_client_active_bits, client_active_ratio);
 		return true;
 	}
 	MSG_T("load_kick_active",
 		  "client "MAC_ADDR_FMT" is inactive (config=%llu) (real=%llu)",
-		  MAC_ADDR_DATA(si->sta->addr), config_kick_active_ratio, client_active_ratio);
+		  MAC_ADDR_DATA(si->sta->addr), config.kick_client_active_bits, client_active_ratio);
 	return false;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -43,5 +43,7 @@
 | `load_kick_delay` | Delay that usteer waits before load-kicking a client. | `10.000` |  `unsigned 32 bit int` |
 | `load_kick_min_clients` | When load-kicking is enabled, this property determines at which point a node stops to load-kick clients based on the amount of connected clients. If the number of connected clients is less than this property, no clients will be kicked even if they are over the load-threshold. | `10` |  `unsigned 32 bit int` |
 | `load_kick_reason_code` | The reason why a client was load-kicked. Default is WLAN_REASON_DISASSOC_AP_BUSY (5) | `5` |  `802.11-2016 Table 9-45 Reason codes ` |
+| `kick_client_active_sec` | The time interval over which the client transfered bits are measured | `30` | `unsigned 32 bit int` |
+| `kick_client_active_kbits` | How many kilobits the client needs to transfer without getting kicked | `50` | `unsigned 32 bit int` |
 | `node_up_script` | executable that is executed after the usteer node starts up. | `0` |  `string` |
 <br>

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,6 @@
 | `load_kick_min_clients` | When load-kicking is enabled, this property determines at which point a node stops to load-kick clients based on the amount of connected clients. If the number of connected clients is less than this property, no clients will be kicked even if they are over the load-threshold. | `10` |  `unsigned 32 bit int` |
 | `load_kick_reason_code` | The reason why a client was load-kicked. Default is WLAN_REASON_DISASSOC_AP_BUSY (5) | `5` |  `802.11-2016 Table 9-45 Reason codes ` |
 | `kick_client_active_sec` | The time interval in which the client transfered bits are measured. Raising this value during runtime will only affect clients that connect after the change. Lowering it will only waste some bits until they disconnect. | `30` | `unsigned 32 bit int` |
-| `kick_client_active_kbits` | How many kilobits per second (average over the time above) the client needs to transfer without getting kicked | `50` | `unsigned 32 bit int` |
+| `kick_client_active_bits` | How many bits per second (average over the time above) the client needs to transfer without getting kicked | `50000` | `unsigned 32 bit int` |
 | `node_up_script` | executable that is executed after the usteer node starts up. | `0` |  `string` |
 <br>

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@
 | `load_kick_delay` | Delay that usteer waits before load-kicking a client. | `10.000` |  `unsigned 32 bit int` |
 | `load_kick_min_clients` | When load-kicking is enabled, this property determines at which point a node stops to load-kick clients based on the amount of connected clients. If the number of connected clients is less than this property, no clients will be kicked even if they are over the load-threshold. | `10` |  `unsigned 32 bit int` |
 | `load_kick_reason_code` | The reason why a client was load-kicked. Default is WLAN_REASON_DISASSOC_AP_BUSY (5) | `5` |  `802.11-2016 Table 9-45 Reason codes ` |
-| `kick_client_active_sec` | The time interval over which the client transfered bits are measured | `30` | `unsigned 32 bit int` |
+| `kick_client_active_sec` | The time interval over which the client transfered bits are measured. Raising this value during runtime will only affect clients that connect after the change. Lowering it will only waste some bits until they disconnect. | `30` | `unsigned 32 bit int` |
 | `kick_client_active_kbits` | How many kilobits the client needs to transfer without getting kicked | `50` | `unsigned 32 bit int` |
 | `node_up_script` | executable that is executed after the usteer node starts up. | `0` |  `string` |
 <br>

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@
 | `load_kick_delay` | Delay that usteer waits before load-kicking a client. | `10.000` |  `unsigned 32 bit int` |
 | `load_kick_min_clients` | When load-kicking is enabled, this property determines at which point a node stops to load-kick clients based on the amount of connected clients. If the number of connected clients is less than this property, no clients will be kicked even if they are over the load-threshold. | `10` |  `unsigned 32 bit int` |
 | `load_kick_reason_code` | The reason why a client was load-kicked. Default is WLAN_REASON_DISASSOC_AP_BUSY (5) | `5` |  `802.11-2016 Table 9-45 Reason codes ` |
-| `kick_client_active_sec` | The time interval over which the client transfered bits are measured. Raising this value during runtime will only affect clients that connect after the change. Lowering it will only waste some bits until they disconnect. | `30` | `unsigned 32 bit int` |
-| `kick_client_active_kbits` | How many kilobits the client needs to transfer without getting kicked | `50` | `unsigned 32 bit int` |
+| `kick_client_active_sec` | The time interval in which the client transfered bits are measured. Raising this value during runtime will only affect clients that connect after the change. Lowering it will only waste some bits until they disconnect. | `30` | `unsigned 32 bit int` |
+| `kick_client_active_kbits` | How many kilobits per second (average over the time above) the client needs to transfer without getting kicked | `50` | `unsigned 32 bit int` |
 | `node_up_script` | executable that is executed after the usteer node starts up. | `0` |  `string` |
 <br>

--- a/sta.c
+++ b/sta.c
@@ -107,7 +107,10 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	list_add(&si->node_list, &node->sta_info);
 	si->created = current_time;
 	*create = true;
-	si->active_bytes.data = calloc(config.kick_client_active_sec + 3, sizeof(struct sta_active_bytes));
+
+	uint32_t kick_active_size = config.kick_client_active_sec + 3;
+	si->active_bytes.data = calloc(kick_active_size, sizeof(struct sta_active_bytes));
+	si->active_bytes.size = kick_active_size;
 
 	return si;
 }

--- a/sta.c
+++ b/sta.c
@@ -49,6 +49,7 @@ usteer_sta_info_del(struct sta_info *si)
 	usteer_timeout_cancel(&tq, &si->timeout);
 	list_del(&si->list);
 	list_del(&si->node_list);
+	free(si->active_bytes.data);
 	free(si);
 
 	if (list_empty(&sta->nodes))
@@ -106,6 +107,8 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	list_add(&si->node_list, &node->sta_info);
 	si->created = current_time;
 	*create = true;
+	uint16_t config_active_seconds = 30;
+	si->active_bytes.data = malloc((config_active_seconds + 3) * sizeof(struct sta_active_bytes));
 
 	return si;
 }

--- a/sta.c
+++ b/sta.c
@@ -107,8 +107,7 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	list_add(&si->node_list, &node->sta_info);
 	si->created = current_time;
 	*create = true;
-	uint16_t config_active_seconds = 30;
-	si->active_bytes.data = calloc(config_active_seconds + 3, sizeof(struct sta_active_bytes));
+	si->active_bytes.data = calloc(config.kick_client_active_sec + 3, sizeof(struct sta_active_bytes));
 
 	return si;
 }

--- a/sta.c
+++ b/sta.c
@@ -108,7 +108,7 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	si->created = current_time;
 	*create = true;
 	uint16_t config_active_seconds = 30;
-	si->active_bytes.data = malloc((config_active_seconds + 3) * sizeof(struct sta_active_bytes));
+	si->active_bytes.data = calloc(config_active_seconds + 3, sizeof(struct sta_active_bytes));
 
 	return si;
 }

--- a/sta.c
+++ b/sta.c
@@ -103,8 +103,6 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	si = calloc(1, sizeof(*si));
 	si->node = node;
 	si->sta = sta;
-	list_add(&si->list, &sta->nodes);
-	list_add(&si->node_list, &node->sta_info);
 	si->created = current_time;
 	*create = true;
 
@@ -112,6 +110,8 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	si->active_bytes.data = calloc(kick_active_size, sizeof(struct sta_active_bytes));
 	si->active_bytes.size = kick_active_size;
 
+	list_add(&si->list, &sta->nodes);
+	list_add(&si->node_list, &node->sta_info);
 	return si;
 }
 

--- a/ubus.c
+++ b/ubus.c
@@ -107,6 +107,7 @@ usteer_ubus_get_client_info(struct ubus_context *ctx, struct ubus_object *obj,
 		for (i = 0; i < __EVENT_TYPE_MAX; i++)
 			usteer_ubus_add_stats(&si->stats[EVENT_TYPE_PROBE], event_types[i]);
 		blobmsg_close_table(&b, _s);
+		blobmsg_add_u64(&b, "average_data_rate", usteer_local_node_active_bytes(si));
 		blobmsg_close_table(&b, _cur_n);
 	}
 	blobmsg_close_table(&b, _n);

--- a/ubus.c
+++ b/ubus.c
@@ -107,7 +107,7 @@ usteer_ubus_get_client_info(struct ubus_context *ctx, struct ubus_object *obj,
 		for (i = 0; i < __EVENT_TYPE_MAX; i++)
 			usteer_ubus_add_stats(&si->stats[EVENT_TYPE_PROBE], event_types[i]);
 		blobmsg_close_table(&b, _s);
-		blobmsg_add_u64(&b, "average_data_rate", usteer_local_node_active_bytes(si));
+		blobmsg_add_u64(&b, "average_data_rate", usteer_local_node_active_bits(si));
 		blobmsg_close_table(&b, _cur_n);
 	}
 	blobmsg_close_table(&b, _n);
@@ -165,7 +165,7 @@ struct cfg_item {
 	_cfg(U32, load_kick_min_clients), \
 	_cfg(U32, load_kick_reason_code), \
 	_cfg(U32, kick_client_active_sec), \
-    _cfg(U32, kick_client_active_kbits), \
+    _cfg(U32, kick_client_active_bits), \
 	_cfg(ARRAY_CB, interfaces), \
 	_cfg(STRING_CB, node_up_script)
 

--- a/ubus.c
+++ b/ubus.c
@@ -163,6 +163,8 @@ struct cfg_item {
 	_cfg(U32, load_kick_delay), \
 	_cfg(U32, load_kick_min_clients), \
 	_cfg(U32, load_kick_reason_code), \
+	_cfg(U32, kick_client_active_sec), \
+    _cfg(U32, kick_client_active_kbits), \
 	_cfg(ARRAY_CB, interfaces), \
 	_cfg(STRING_CB, node_up_script)
 

--- a/usteer.h
+++ b/usteer.h
@@ -60,7 +60,7 @@ struct sta_active_bytes {
 
 struct sta_active_bytes_queue {
 	struct sta_active_bytes *data;
-	uint16_t index;
+	uint32_t index;
 };
 
 struct usteer_node {
@@ -162,6 +162,9 @@ struct usteer_config {
 	uint32_t load_kick_delay;
 	uint32_t load_kick_min_clients;
 	uint32_t load_kick_reason_code;
+
+	uint32_t kick_client_active_sec;
+	uint32_t kick_client_active_kbits;
 
 	const char *node_up_script;
 };

--- a/usteer.h
+++ b/usteer.h
@@ -53,6 +53,16 @@ enum usteer_node_type {
 struct sta_info;
 struct usteer_local_node;
 
+struct sta_active_bytes {
+	uint64_t rx;
+	uint64_t tx;
+};
+
+struct sta_active_bytes_queue {
+	struct sta_active_bytes *data;
+	uint16_t index;
+};
+
 struct usteer_node {
 	struct avl_node avl;
 	struct list_head sta_info;
@@ -198,6 +208,7 @@ struct sta_info {
 	uint64_t roam_scan_done;
 
 	int kick_count;
+	struct sta_active_bytes_queue active_bytes;
 
 	uint8_t scan_band : 1;
 	uint8_t connected : 2;

--- a/usteer.h
+++ b/usteer.h
@@ -61,6 +61,7 @@ struct sta_active_bytes {
 struct sta_active_bytes_queue {
 	struct sta_active_bytes *data;
 	uint32_t index;
+	uint32_t size;
 };
 
 struct usteer_node {

--- a/usteer.h
+++ b/usteer.h
@@ -165,7 +165,7 @@ struct usteer_config {
 	uint32_t load_kick_reason_code;
 
 	uint32_t kick_client_active_sec;
-	uint32_t kick_client_active_kbits;
+	uint32_t kick_client_active_bits;
 
 	const char *node_up_script;
 };
@@ -243,7 +243,7 @@ bool usteer_handle_sta_event(struct usteer_node *node, const uint8_t *addr,
 void usteer_local_nodes_init(struct ubus_context *ctx);
 void usteer_local_node_kick(struct usteer_local_node *ln);
 
-uint64_t usteer_local_node_active_bytes(struct sta_info *si);
+uint64_t usteer_local_node_active_bits(struct sta_info *si);
 
 void usteer_ubus_init(struct ubus_context *ctx);
 void usteer_ubus_kick_client(struct sta_info *si);

--- a/usteer.h
+++ b/usteer.h
@@ -243,6 +243,8 @@ bool usteer_handle_sta_event(struct usteer_node *node, const uint8_t *addr,
 void usteer_local_nodes_init(struct ubus_context *ctx);
 void usteer_local_node_kick(struct usteer_local_node *ln);
 
+uint64_t usteer_local_node_active_bytes(struct sta_info *si);
+
 void usteer_ubus_init(struct ubus_context *ctx);
 void usteer_ubus_kick_client(struct sta_info *si);
 int usteer_ubus_trigger_client_scan(struct sta_info *si);


### PR DESCRIPTION
As a stakeholder, we want that only inactive clients get disconnected from any Access Point.

Acceptance Criteria:
- Only kick clients which have a data rate of <50 kbit/s withing the last 30 seconds (VOIP calls!).
- So if 50kbit/s is transmitted in TX or RX direction, the client should not be disconnected.
- 50 kbit/s should be the default value. Make a config switch.